### PR TITLE
Set PHPDoc for the constructor of a Quote in the correct order

### DIFF
--- a/src/Backend/Modules/Quotes/Entity/Quote.php
+++ b/src/Backend/Modules/Quotes/Entity/Quote.php
@@ -39,8 +39,8 @@ final class Quote
      * @param string $createdOn
      * @param string $editedOn
      * @param string $language
-     * @param int|null $id
      * @param string|null $image
+     * @param int|null $id
      * @param int|null $modulesExtrasId
      */
     private function __construct(


### PR DESCRIPTION
Set PHPDoc for the constructor of a Quote in the same order as the parameters.
