### PR TITLE
Image loading when there isn't one set

### DIFF
--- a/src/Backend/Modules/Quotes/Entity/Quote.php
+++ b/src/Backend/Modules/Quotes/Entity/Quote.php
@@ -204,7 +204,9 @@ final class Quote
      */
     public function getPreviewImage()
     {
-        return self::getImageDirectoryUrl('x150') . '/' . $this->image;
+        if ($this->image !== null){
+            return self::getImageDirectoryUrl('x150') . '/' . $this->image;
+        }
     }
 
     /**


### PR DESCRIPTION
Backend tries to load an image even it is nog set by user, resulting in a broken one.
Adding check if image is set first.